### PR TITLE
[PUT Project] Add format support for Raviewer formats and MJPEG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(${PROJECT_NAME} SHARED
     src/mmapbuffer.cpp
     src/frameconverter.cpp
     src/frameconverters/yuv2bgrconverter.cpp
+    src/frameconverters/packedformats2rgbconverter.cpp
     src/frameconverters/bayer2bgrconverter.cpp
     src/frameconverters/anyformat2bgrconverter.cpp
     src/utils.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ find_package(RapidJSON REQUIRED)
 
 option(ADD_GRABTHECAM_FARSHOW_DEMO "Adds a target for grabthecam-farshow integration demo" OFF)
 
+option(BUILD_TESTS "Enables building of testing binaries" OFF)
+
 set(INCLUDE_DIRECTORIES
     ${OpenCV_INCLUDE_DIRS}
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -55,6 +57,22 @@ target_link_libraries(${PROJECT_NAME}-demo PUBLIC
     ${OpenCV_LIBS}
 )
 
+if(BUILD_TESTS)
+    add_executable(${PROJECT_NAME}-test-frame-fetch
+        tests/test_frame_fetch.cpp
+    )
+
+    target_include_directories(${PROJECT_NAME}-test-frame-fetch PUBLIC ${INCLUDE_DIRECTORIES})
+
+    target_link_libraries(${PROJECT_NAME}-test-frame-fetch PRIVATE
+        ${PROJECT_NAME}
+    )
+
+    target_link_libraries(${PROJECT_NAME}-test-frame-fetch PUBLIC
+        v4l2
+        ${OpenCV_LIBS}
+    )
+endif()
 
 if(ADD_GRABTHECAM_FARSHOW_DEMO)
     find_package(farshow QUIET)

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ In order to add the option to build a `grabthecam` - `farshow` integration demo,
 cmake -S . -B build -DADD_GRABTHECAM_FARSHOW_DEMO=ON
 ```
 
+Moreover, to build test binaries, execute:
+```
+cmake -S . -B build -DBUILD_TESTS=ON
+```
+
+Please note that the two added options can be combined into one command if necessary.
+
 Next, go to `build` and execute either
 ```
 make

--- a/README.md
+++ b/README.md
@@ -220,6 +220,35 @@ To add a new converter, simply create a new class, inheriting from `FrameConvert
 
 If you would like to use your converter in the demo, go to `src/example.cpp`. Add the converter to options, `pix_formats` and create a case for it in the `setConverter` function. You should also add your cpp file to `CMakeLists.txt` to allow automatic build.
 
+
+## FrameConverter compatibility lookup
+
+The FrameConverters are specific to raw input formats.
+Specific formats can have multiple working setups, but one was tested and verified for most common types.
+Those include (please note that specifying the `cv::Mat` format to `grabthecam::read()` is the best practice to ensure compatibility):
+
+- RGB24: no converter necessary
+- BGR24, MJPEG: AnyFormat2BGRConverter COLOR_BGR2RGB CV_8UC3
+- RGBA32: AnyFormat2BGRConverter COLOR_RGBA2RGB CV_8UC4, CV_8UC4
+- ABGR32: AnyFormat2BGRConverter COLOR_BGRA2BGR CV_8UC4
+- BGRA32, ARGB32: Channel swapping issues with OpenCV internal conversion codes, no error with RGBA32 settings
+- RGB332, RGB565, ARGB444, ABGR444, RGBA444, BGRA444, ARGB555, ABGR555, RGBA555, BGRA555: PackedFormats2RGBconverter PACKED_<name_of_format>
+- GRAY: no converter necessary
+- YUY2: Yuv2BGRConverter COLOR_YUV2RGB 
+- UYVY: Yuv2BGRConverter COLOR_YUV2BGR_UYVY 
+- YVYU: Yuv2BGRConverter COLOR_YUV2BGR_YVYU 
+- GRAY10, GRAY12: unsupported in `v4l2`
+- RGGB, BGGR, GBRG, GRBG: Bayer2BGRConverter, COLOR_Bayer<name_of_format>2BGR_EA
+- RG10, RG12, RG16: Bayer2BGRConverter, COLOR_BayerRGGB2BGR_EA, CV_16UC1
+
+For packed YCbCr formats, a rescaling factor is provided to the frame writing method.
+Thus, usage of `grabthecam::read(mat_type)` is required with a specified type.
+
+- NV12: Yuv2BGRConverter COLOR_YUV2BGR_NV12
+- NV21: Yuv2BGRConverter COLOR_YUV2BGR_NV21
+- YUV420: Yuv2BGRConverter COLOR_YUV2BGR_I420
+- YVU420: Yuv2BGRConverter COLOR_YUV2BGR_YV12
+
 ## Licensing
 
 The sources are published under the Apache 2.0 License, except for files located in the `third-party/` directory. For those files, the license is either enclosed in the file header or a separate LICENSE file.

--- a/include/grabthecam/cameracapture.hpp
+++ b/include/grabthecam/cameracapture.hpp
@@ -10,9 +10,10 @@
 #include <functional>
 #include <opencv2/core/mat.hpp> // cv::Mat
 #include <optional>
+#include <type_traits>
 
 template <typename T>
-concept Numeric = std::integral<T> or std::floating_point<T>;
+concept numeric = std::integral<T> or std::floating_point<T>;
 
 namespace grabthecam
 {
@@ -116,7 +117,7 @@ public:
      * @param value Value for the parameter
      * @param warning Print warning to stderr when the value was clamped
      */
-    template <Numeric T> void set(int property, T value, bool warning = true);
+    template <numeric T> void set(int property, T value, bool warning = true);
 
     /**
      * Run ioctl code
@@ -138,7 +139,7 @@ public:
      * @param current Whether to get currently set value. If it's set to false, the default parameter's value is
      * returned
      */
-    template <Numeric T> void get(int property, T &value, bool current = true) const;
+    template <numeric T> void get(int property, T &value, bool current = true) const;
 
     /**
      * Set the camera frame format to a given value
@@ -443,6 +444,7 @@ private:
     int fd;                                           ///< A file descriptor to the opened camera
     int width;                                        ///< Frame width in pixels, currently set on the camera
     int height;                                       ///< Frame width in pixels, currently set on the camera
+    int v4l2_format_code = 0;                         ///< V4L2_PIX_FMT code, currently set on the camera
     bool ready_to_capture;                            ///< If the buffers are allocated and stream is active
     std::shared_ptr<v4l2_buffer> info_buffer;         ///< Informations about the current buffer
     int buffer_type = V4L2_BUF_TYPE_VIDEO_CAPTURE;    ///< Type of the allocated buffer

--- a/include/grabthecam/cameracapturetemplates.hpp
+++ b/include/grabthecam/cameracapturetemplates.hpp
@@ -3,7 +3,7 @@
 namespace grabthecam
 {
 
-template <Numeric T> void CameraCapture::set(int property, T value, bool warning)
+template <numeric T> void CameraCapture::set(int property, T value, bool warning)
 {
     v4l2_ext_control ctrl[1];
     memset(&ctrl, 0, sizeof(ctrl));
@@ -12,7 +12,7 @@ template <Numeric T> void CameraCapture::set(int property, T value, bool warning
     setCtrl(property, ctrl, warning);
 }
 
-template <Numeric T> void CameraCapture::get(int property, T &value, bool current) const
+template <numeric T> void CameraCapture::get(int property, T &value, bool current) const
 {
     v4l2_ext_controls ctrls;
     getCtrls(property, current, ctrls);

--- a/include/grabthecam/frameconverters/packedformats2rgbconverter.hpp
+++ b/include/grabthecam/frameconverters/packedformats2rgbconverter.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "grabthecam/frameconverter.hpp"
+
+namespace grabthecam
+{
+
+typedef enum PackedFormatEnum
+{
+    PACKED_RGB332,
+    PACKED_RGB565,
+    PACKED_RGBA444,
+    PACKED_BGRA444,
+    PACKED_ARGB444,
+    PACKED_ABGR444,
+    PACKED_RGBA555,
+    PACKED_BGRA555,
+    PACKED_ARGB555,
+    PACKED_ABGR555
+
+} PackedFormatEnum;
+
+class PackedFormats2RGBconverter : public FrameConverter
+{
+public:
+    PackedFormats2RGBconverter(PackedFormatEnum type, int input_format = CV_8UC2)
+    {
+        this->input_format = input_format;
+        this->type = type;
+    }
+    cv::Mat convert(cv::Mat src) override;
+
+private:
+    PackedFormatEnum type;
+};
+
+}; // namespace grabthecam

--- a/include/grabthecam/pixelformatsinfo.hpp
+++ b/include/grabthecam/pixelformatsinfo.hpp
@@ -3,8 +3,10 @@
 #include "grabthecam/frameconverters/anyformat2bgrconverter.hpp"
 #include "grabthecam/frameconverters/bayer2bgrconverter.hpp"
 #include "grabthecam/frameconverters/yuv2bgrconverter.hpp"
+#include "grabthecam/frameconverters/packedformats2rgbconverter.hpp"
 #include "opencv2/imgproc.hpp"
 #include <iostream>
+#include <map>
 #include <linux/videodev2.h>
 
 namespace grabthecam
@@ -26,15 +28,33 @@ uint32_t convertToV4l2Fourcc(std::string name)
 }
 
 /// Information about converters and input formats assigned to pixel formats
-static std::unordered_map<unsigned int, std::function<std::shared_ptr<FrameConverter>()>> formats_info = {
-    {V4L2_PIX_FMT_YYUV, [] { return std::make_shared<Yuv2BGRConverter>(cv::COLOR_YUV2BGR_YUY2); }},
-    {V4L2_PIX_FMT_YUYV, [] { return std::make_shared<Yuv2BGRConverter>(cv::COLOR_YUV2BGR_YUY2); }},
-    {V4L2_PIX_FMT_ABGR32,
-     [] { return std::make_shared<AnyFormat2BGRConverter>(cv::COLOR_BGRA2RGB, CV_8UC3, CV_8UC4); }},
-    {V4L2_PIX_FMT_SRGGB8, [] { return std::make_shared<Bayer2BGRConverter>(cv::COLOR_BayerRG2BGR); }},
-    {V4L2_PIX_FMT_SRGGB12,
-     [] { return std::make_shared<Bayer2BGRConverter>(cv::COLOR_BayerRGGB2BGR_EA, CV_16UC1, CV_16UC3); }},
-    {V4L2_PIX_FMT_SRGGB10,
-     [] { return std::make_shared<Bayer2BGRConverter>(cv::COLOR_BayerRGGB2BGR_EA, CV_16UC1, CV_16UC3); }}};
+static std::map<unsigned int, std::function<std::shared_ptr<FrameConverter>()>> formats_info = {
+    {V4L2_PIX_FMT_MJPEG, [] { return std::make_shared<AnyFormat2BGRConverter>(cv::COLOR_BGRA2BGR, CV_8UC3); }},
+    {V4L2_PIX_FMT_RGB24, [] { return std::make_shared<AnyFormat2BGRConverter>(cv::COLOR_RGB2BGR, CV_8UC3); }},
+    {V4L2_PIX_FMT_RGBA32, [] { return std::make_shared<AnyFormat2BGRConverter>(cv::COLOR_RGBA2BGR, CV_8UC4); }},
+    {V4L2_PIX_FMT_ABGR32, [] { return std::make_shared<AnyFormat2BGRConverter>(cv::COLOR_BGRA2BGR, CV_8UC4); }},
+    {V4L2_PIX_FMT_RGB332, [] { return std::make_shared<PackedFormats2RGBconverter>(grabthecam::PACKED_RGB332, CV_8UC1); }},
+    {V4L2_PIX_FMT_RGB565, [] { return std::make_shared<PackedFormats2RGBconverter>(grabthecam::PACKED_RGB565, CV_16UC1); }},
+    {V4L2_PIX_FMT_ARGB444, [] { return std::make_shared<PackedFormats2RGBconverter>(grabthecam::PACKED_ARGB444, CV_16UC1); }},
+    {V4L2_PIX_FMT_ABGR444, [] { return std::make_shared<PackedFormats2RGBconverter>(grabthecam::PACKED_ABGR444, CV_16UC1); }},
+    {V4L2_PIX_FMT_RGBA444, [] { return std::make_shared<PackedFormats2RGBconverter>(grabthecam::PACKED_RGBA444, CV_16UC1); }},
+    {V4L2_PIX_FMT_BGRA444, [] { return std::make_shared<PackedFormats2RGBconverter>(grabthecam::PACKED_BGRA444, CV_16UC1); }},
+    {V4L2_PIX_FMT_ARGB555, [] { return std::make_shared<PackedFormats2RGBconverter>(grabthecam::PACKED_ARGB555, CV_16UC1); }},
+    {V4L2_PIX_FMT_ABGR555, [] { return std::make_shared<PackedFormats2RGBconverter>(grabthecam::PACKED_ABGR555, CV_16UC1); }},
+    {V4L2_PIX_FMT_RGBA555, [] { return std::make_shared<PackedFormats2RGBconverter>(grabthecam::PACKED_RGBA555, CV_16UC1); }},
+    {V4L2_PIX_FMT_BGRA555, [] { return std::make_shared<PackedFormats2RGBconverter>(grabthecam::PACKED_BGRA555, CV_16UC1); }},
+    {V4L2_PIX_FMT_YUYV, [] { return std::make_shared<Yuv2BGRConverter>(cv::COLOR_YUV2BGR_YUYV); }},
+    {V4L2_PIX_FMT_UYVY, [] { return std::make_shared<Yuv2BGRConverter>(cv::COLOR_YUV2BGR_UYVY); }},
+    {V4L2_PIX_FMT_YVYU, [] { return std::make_shared<Yuv2BGRConverter>(cv::COLOR_YUV2BGR_YVYU); }},
+    {V4L2_PIX_FMT_NV12, [] { return std::make_shared<Yuv2BGRConverter>(cv::COLOR_YUV2BGR_NV12, CV_8UC1); }},
+    {V4L2_PIX_FMT_NV21, [] { return std::make_shared<Yuv2BGRConverter>(cv::COLOR_YUV2BGR_NV21, CV_8UC1); }},
+    {V4L2_PIX_FMT_YVU420, [] { return std::make_shared<Yuv2BGRConverter>(cv::COLOR_YUV2BGR_YV12, CV_8UC1); }},
+    {V4L2_PIX_FMT_YUV420, [] { return std::make_shared<Yuv2BGRConverter>(cv::COLOR_YUV2BGR_I420, CV_8UC1); }},
+    {V4L2_PIX_FMT_SBGGR8, [] { return std::make_shared<Bayer2BGRConverter>(cv::COLOR_BayerBGGR2BGR_EA, CV_8UC1, CV_8UC3); }},
+    {V4L2_PIX_FMT_SGBRG8, [] { return std::make_shared<Bayer2BGRConverter>(cv::COLOR_BayerGBRG2BGR_EA, CV_8UC1, CV_8UC3); }},
+    {V4L2_PIX_FMT_SRGGB16, [] { return std::make_shared<Bayer2BGRConverter>(cv::COLOR_BayerRGGB2BGR_EA, CV_16UC1, CV_16UC3); }},
+    {V4L2_PIX_FMT_SRGGB8, [] { return std::make_shared<Bayer2BGRConverter>(cv::COLOR_BayerRGGB2BGR_EA, CV_8UC1, CV_8UC3); }},
+    {V4L2_PIX_FMT_SRGGB10, [] { return std::make_shared<Bayer2BGRConverter>(cv::COLOR_BayerRGGB2BGR_EA, CV_16UC1, CV_8UC3); }},
+    {V4L2_PIX_FMT_SRGGB12, [] { return std::make_shared<Bayer2BGRConverter>(cv::COLOR_BayerRGGB2BGR_EA, CV_16UC1, CV_8UC3); }}};
 
 }; // namespace grabthecam

--- a/include/grabthecam/pixelformatsinfo.hpp
+++ b/include/grabthecam/pixelformatsinfo.hpp
@@ -33,8 +33,8 @@ static std::unordered_map<unsigned int, std::function<std::shared_ptr<FrameConve
      [] { return std::make_shared<AnyFormat2BGRConverter>(cv::COLOR_BGRA2RGB, CV_8UC3, CV_8UC4); }},
     {V4L2_PIX_FMT_SRGGB8, [] { return std::make_shared<Bayer2BGRConverter>(cv::COLOR_BayerRG2BGR); }},
     {V4L2_PIX_FMT_SRGGB12,
-     [] { return std::make_shared<Bayer2BGRConverter>(cv::COLOR_BayerRG2BGR, CV_16UC1, CV_16UC3); }},
+     [] { return std::make_shared<Bayer2BGRConverter>(cv::COLOR_BayerRGGB2BGR_EA, CV_16UC1, CV_16UC3); }},
     {V4L2_PIX_FMT_SRGGB10,
-     [] { return std::make_shared<Bayer2BGRConverter>(cv::COLOR_BayerRG2BGR, CV_16UC1, CV_16UC3); }}};
+     [] { return std::make_shared<Bayer2BGRConverter>(cv::COLOR_BayerRGGB2BGR_EA, CV_16UC1, CV_16UC3); }}};
 
 }; // namespace grabthecam

--- a/include/grabthecam/pixelformatsinfo.hpp
+++ b/include/grabthecam/pixelformatsinfo.hpp
@@ -2,12 +2,12 @@
 
 #include "grabthecam/frameconverters/anyformat2bgrconverter.hpp"
 #include "grabthecam/frameconverters/bayer2bgrconverter.hpp"
-#include "grabthecam/frameconverters/yuv2bgrconverter.hpp"
 #include "grabthecam/frameconverters/packedformats2rgbconverter.hpp"
+#include "grabthecam/frameconverters/yuv2bgrconverter.hpp"
 #include "opencv2/imgproc.hpp"
 #include <iostream>
-#include <map>
 #include <linux/videodev2.h>
+#include <map>
 
 namespace grabthecam
 {
@@ -33,16 +33,26 @@ static std::map<unsigned int, std::function<std::shared_ptr<FrameConverter>()>> 
     {V4L2_PIX_FMT_RGB24, [] { return std::make_shared<AnyFormat2BGRConverter>(cv::COLOR_RGB2BGR, CV_8UC3); }},
     {V4L2_PIX_FMT_RGBA32, [] { return std::make_shared<AnyFormat2BGRConverter>(cv::COLOR_RGBA2BGR, CV_8UC4); }},
     {V4L2_PIX_FMT_ABGR32, [] { return std::make_shared<AnyFormat2BGRConverter>(cv::COLOR_BGRA2BGR, CV_8UC4); }},
-    {V4L2_PIX_FMT_RGB332, [] { return std::make_shared<PackedFormats2RGBconverter>(grabthecam::PACKED_RGB332, CV_8UC1); }},
-    {V4L2_PIX_FMT_RGB565, [] { return std::make_shared<PackedFormats2RGBconverter>(grabthecam::PACKED_RGB565, CV_16UC1); }},
-    {V4L2_PIX_FMT_ARGB444, [] { return std::make_shared<PackedFormats2RGBconverter>(grabthecam::PACKED_ARGB444, CV_16UC1); }},
-    {V4L2_PIX_FMT_ABGR444, [] { return std::make_shared<PackedFormats2RGBconverter>(grabthecam::PACKED_ABGR444, CV_16UC1); }},
-    {V4L2_PIX_FMT_RGBA444, [] { return std::make_shared<PackedFormats2RGBconverter>(grabthecam::PACKED_RGBA444, CV_16UC1); }},
-    {V4L2_PIX_FMT_BGRA444, [] { return std::make_shared<PackedFormats2RGBconverter>(grabthecam::PACKED_BGRA444, CV_16UC1); }},
-    {V4L2_PIX_FMT_ARGB555, [] { return std::make_shared<PackedFormats2RGBconverter>(grabthecam::PACKED_ARGB555, CV_16UC1); }},
-    {V4L2_PIX_FMT_ABGR555, [] { return std::make_shared<PackedFormats2RGBconverter>(grabthecam::PACKED_ABGR555, CV_16UC1); }},
-    {V4L2_PIX_FMT_RGBA555, [] { return std::make_shared<PackedFormats2RGBconverter>(grabthecam::PACKED_RGBA555, CV_16UC1); }},
-    {V4L2_PIX_FMT_BGRA555, [] { return std::make_shared<PackedFormats2RGBconverter>(grabthecam::PACKED_BGRA555, CV_16UC1); }},
+    {V4L2_PIX_FMT_RGB332,
+     [] { return std::make_shared<PackedFormats2RGBconverter>(grabthecam::PACKED_RGB332, CV_8UC1); }},
+    {V4L2_PIX_FMT_RGB565,
+     [] { return std::make_shared<PackedFormats2RGBconverter>(grabthecam::PACKED_RGB565, CV_16UC1); }},
+    {V4L2_PIX_FMT_ARGB444,
+     [] { return std::make_shared<PackedFormats2RGBconverter>(grabthecam::PACKED_ARGB444, CV_16UC1); }},
+    {V4L2_PIX_FMT_ABGR444,
+     [] { return std::make_shared<PackedFormats2RGBconverter>(grabthecam::PACKED_ABGR444, CV_16UC1); }},
+    {V4L2_PIX_FMT_RGBA444,
+     [] { return std::make_shared<PackedFormats2RGBconverter>(grabthecam::PACKED_RGBA444, CV_16UC1); }},
+    {V4L2_PIX_FMT_BGRA444,
+     [] { return std::make_shared<PackedFormats2RGBconverter>(grabthecam::PACKED_BGRA444, CV_16UC1); }},
+    {V4L2_PIX_FMT_ARGB555,
+     [] { return std::make_shared<PackedFormats2RGBconverter>(grabthecam::PACKED_ARGB555, CV_16UC1); }},
+    {V4L2_PIX_FMT_ABGR555,
+     [] { return std::make_shared<PackedFormats2RGBconverter>(grabthecam::PACKED_ABGR555, CV_16UC1); }},
+    {V4L2_PIX_FMT_RGBA555,
+     [] { return std::make_shared<PackedFormats2RGBconverter>(grabthecam::PACKED_RGBA555, CV_16UC1); }},
+    {V4L2_PIX_FMT_BGRA555,
+     [] { return std::make_shared<PackedFormats2RGBconverter>(grabthecam::PACKED_BGRA555, CV_16UC1); }},
     {V4L2_PIX_FMT_YUYV, [] { return std::make_shared<Yuv2BGRConverter>(cv::COLOR_YUV2BGR_YUYV); }},
     {V4L2_PIX_FMT_UYVY, [] { return std::make_shared<Yuv2BGRConverter>(cv::COLOR_YUV2BGR_UYVY); }},
     {V4L2_PIX_FMT_YVYU, [] { return std::make_shared<Yuv2BGRConverter>(cv::COLOR_YUV2BGR_YVYU); }},
@@ -50,11 +60,14 @@ static std::map<unsigned int, std::function<std::shared_ptr<FrameConverter>()>> 
     {V4L2_PIX_FMT_NV21, [] { return std::make_shared<Yuv2BGRConverter>(cv::COLOR_YUV2BGR_NV21, CV_8UC1); }},
     {V4L2_PIX_FMT_YVU420, [] { return std::make_shared<Yuv2BGRConverter>(cv::COLOR_YUV2BGR_YV12, CV_8UC1); }},
     {V4L2_PIX_FMT_YUV420, [] { return std::make_shared<Yuv2BGRConverter>(cv::COLOR_YUV2BGR_I420, CV_8UC1); }},
-    {V4L2_PIX_FMT_SBGGR8, [] { return std::make_shared<Bayer2BGRConverter>(cv::COLOR_BayerBGGR2BGR_EA, CV_8UC1, CV_8UC3); }},
-    {V4L2_PIX_FMT_SGBRG8, [] { return std::make_shared<Bayer2BGRConverter>(cv::COLOR_BayerGBRG2BGR_EA, CV_8UC1, CV_8UC3); }},
-    {V4L2_PIX_FMT_SRGGB16, [] { return std::make_shared<Bayer2BGRConverter>(cv::COLOR_BayerRGGB2BGR_EA, CV_16UC1, CV_16UC3); }},
-    {V4L2_PIX_FMT_SRGGB8, [] { return std::make_shared<Bayer2BGRConverter>(cv::COLOR_BayerRGGB2BGR_EA, CV_8UC1, CV_8UC3); }},
-    {V4L2_PIX_FMT_SRGGB10, [] { return std::make_shared<Bayer2BGRConverter>(cv::COLOR_BayerRGGB2BGR_EA, CV_16UC1, CV_8UC3); }},
-    {V4L2_PIX_FMT_SRGGB12, [] { return std::make_shared<Bayer2BGRConverter>(cv::COLOR_BayerRGGB2BGR_EA, CV_16UC1, CV_8UC3); }}};
+    {V4L2_PIX_FMT_SBGGR8, [] { return std::make_shared<Bayer2BGRConverter>(cv::COLOR_BayerBG2BGR, CV_8UC1, CV_8UC3); }},
+    {V4L2_PIX_FMT_SGBRG8, [] { return std::make_shared<Bayer2BGRConverter>(cv::COLOR_BayerGB2BGR, CV_8UC1, CV_8UC3); }},
+    {V4L2_PIX_FMT_SRGGB16,
+     [] { return std::make_shared<Bayer2BGRConverter>(cv::COLOR_BayerRG2BGR, CV_16UC1, CV_16UC3); }},
+    {V4L2_PIX_FMT_SRGGB8, [] { return std::make_shared<Bayer2BGRConverter>(cv::COLOR_BayerRG2BGR, CV_8UC1, CV_8UC3); }},
+    {V4L2_PIX_FMT_SRGGB10,
+     [] { return std::make_shared<Bayer2BGRConverter>(cv::COLOR_BayerRG2BGR, CV_16UC1, CV_8UC3); }},
+    {V4L2_PIX_FMT_SRGGB12,
+     [] { return std::make_shared<Bayer2BGRConverter>(cv::COLOR_BayerRG2BGR, CV_16UC1, CV_8UC3); }}};
 
 }; // namespace grabthecam

--- a/src/frameconverters/bayer2bgrconverter.cpp
+++ b/src/frameconverters/bayer2bgrconverter.cpp
@@ -8,7 +8,15 @@ namespace grabthecam
 cv::Mat Bayer2BGRConverter::convert(cv::Mat src)
 {
     cv::Mat processed_frame = cv::Mat(src.rows, src.cols, dest_mat_type);
-    cv::demosaicing(src, processed_frame, code, nchannels);
+    if (this->input_format == CV_16UC1)
+    {
+        src.convertTo(src, CV_8UC1);
+        cv::demosaicing(src, processed_frame, code, nchannels);
+    }
+    else
+    {
+        cv::demosaicing(src, processed_frame, code, nchannels);
+    }
     return processed_frame;
 }
 

--- a/src/frameconverters/packedformats2rgbconverter.cpp
+++ b/src/frameconverters/packedformats2rgbconverter.cpp
@@ -1,0 +1,168 @@
+#include "grabthecam/frameconverters/packedformats2rgbconverter.hpp"
+#include "grabthecam/cameracapture.hpp"
+
+#include <opencv2/imgproc.hpp>
+
+namespace grabthecam
+{
+
+cv::Mat PackedFormats2RGBconverter::convert(cv::Mat src)
+{
+    cv::Mat rgb_image(src.rows, src.cols, CV_8UC3);
+    switch (this->type)
+    {
+    case PACKED_RGB332:
+    {
+        // Make sure that for camera.capture() there is a format argument
+        // set to CV_8UC1
+        if (src.type() != CV_8UC1)
+        {
+            throw(CameraException("Please set the correct format for camera.capture()\n"));
+        }
+        for (int y = 0; y < src.rows; ++y)
+        {
+            for (int x = 0; x < src.cols; ++x)
+            {
+                uint8_t pixel = src.at<uint8_t>(y, x);
+                uint8_t r = ((pixel >> 5) & 0x07) * 255 / 7;
+                uint8_t g = ((pixel >> 2) & 0x07) * 255 / 7;
+                uint8_t b = ((pixel)&0x03) * 255 / 3;
+                rgb_image.at<cv::Vec3b>(y, x) = cv::Vec3b(b, g, r);
+            }
+        }
+        break;
+    }
+    case PACKED_RGB565:
+    {
+        // Make sure that for camera.capture() there is a format argument
+        // set to CV_16UC1
+        if (src.type() != CV_16UC1)
+        {
+            throw(CameraException("Please set the correct format for camera.capture()\n"));
+        }
+        for (int y = 0; y < src.rows; ++y)
+        {
+            for (int x = 0; x < src.cols; ++x)
+            {
+                uint16_t pixel = src.at<uint16_t>(y, x);
+                uint8_t r = ((pixel >> 11) & 0x1f) * 255 / 0x1f;
+                uint8_t g = ((pixel >> 5) & 0x3f) * 255 / 0x3f;
+                uint8_t b = ((pixel)&0x01f) * 255 / 0x1f;
+                rgb_image.at<cv::Vec3b>(y, x) = cv::Vec3b(b, g, r);
+            }
+        }
+        break;
+    }
+    case PACKED_RGBA444:
+    case PACKED_BGRA444:
+    {
+        // Make sure that for camera.capture() there is a format argument
+        // set to CV_16UC1
+        if (src.type() != CV_16UC1)
+        {
+            throw(CameraException("Please set the correct format for camera.capture()\n"));
+        }
+        for (int y = 0; y < src.rows; ++y)
+        {
+            for (int x = 0; x < src.cols; ++x)
+            {
+                uint16_t pixel = src.at<uint16_t>(y, x);
+
+                uint8_t r = ((pixel >> 12) & 0x0F) * 255 / 0x0F;
+                uint8_t g = ((pixel >> 8) & 0x0F) * 255 / 0x0F;
+                uint8_t b = ((pixel >> 4) & 0x0F) * 255 / 0x0F;
+                if (this->type == PACKED_BGRA444)
+                {
+                    std::swap(r, b);
+                }
+                rgb_image.at<cv::Vec3b>(y, x) = cv::Vec3b(b, g, r);
+            }
+        }
+        break;
+    }
+    case PACKED_ARGB444:
+    case PACKED_ABGR444:
+    {
+        // Make sure that for camera.capture() there is a format argument
+        // set to CV_16UC1
+        if (src.type() != CV_16UC1)
+        {
+            throw(CameraException("Please set the correct format for camera.capture()\n"));
+        }
+        for (int y = 0; y < src.rows; ++y)
+        {
+            for (int x = 0; x < src.cols; ++x)
+            {
+                uint16_t pixel = src.at<uint16_t>(y, x);
+
+                uint8_t r = ((pixel >> 8) & 0x0F) * 255 / 0x0F;
+                uint8_t g = ((pixel >> 4) & 0x0F) * 255 / 0x0F;
+                uint8_t b = ((pixel)&0x0F) * 255 / 0x0F;
+                if (this->type == PACKED_ABGR444)
+                {
+                    std::swap(r, b);
+                }
+                rgb_image.at<cv::Vec3b>(y, x) = cv::Vec3b(b, g, r);
+            }
+        }
+        break;
+    }
+    case PACKED_RGBA555:
+    case PACKED_BGRA555:
+    {
+        // Make sure that for camera.capture() there is a format argument
+        // set to CV_16UC1
+        if (src.type() != CV_16UC1)
+        {
+            throw(CameraException("Please set the correct format for camera.capture()\n"));
+        }
+        for (int y = 0; y < src.rows; ++y)
+        {
+            for (int x = 0; x < src.cols; ++x)
+            {
+                uint16_t pixel = src.at<uint16_t>(y, x);
+
+                uint8_t r = ((pixel >> 11) & 0x1F) * 255 / 0x1F;
+                uint8_t g = (((pixel >> 5) & 0x3) | (((pixel >> 8) & 0x7) << 2)) * 255 / 0x1F;
+                uint8_t b = ((pixel >> 1) & 0x1F) * 255 / 0x1F;
+                if (this->type == PACKED_BGRA555)
+                {
+                    std::swap(r, b);
+                }
+                rgb_image.at<cv::Vec3b>(y, x) = cv::Vec3b(b, g, r);
+            }
+        }
+        break;
+    }
+    case PACKED_ARGB555:
+    case PACKED_ABGR555:
+    {
+        // Make sure that for camera.capture() there is a format argument
+        // set to CV_16UC1
+        if (src.type() != CV_16UC1)
+        {
+            throw(CameraException("Please set the correct format for camera.capture()\n"));
+        }
+        for (int y = 0; y < src.rows; ++y)
+        {
+            for (int x = 0; x < src.cols; ++x)
+            {
+                uint16_t pixel = src.at<uint16_t>(y, x);
+
+                uint8_t r = ((pixel >> 10) & 0x1F) * 255 / 0x1F;
+                uint8_t g = (((pixel >> 5) & 0x7) | (((pixel >> 8) & 0x3) << 3)) * 255 / 0x1F;
+                uint8_t b = ((pixel)&0x1F) * 255 / 0x1F;
+                if (this->type == PACKED_ABGR555)
+                {
+                    std::swap(r, b);
+                }
+                rgb_image.at<cv::Vec3b>(y, x) = cv::Vec3b(b, g, r);
+            }
+        }
+        break;
+    }
+    }
+    return rgb_image;
+}
+
+}; // namespace grabthecam

--- a/tests/test_frame_fetch.cpp
+++ b/tests/test_frame_fetch.cpp
@@ -1,0 +1,32 @@
+#include "grabthecam/cameracapture.hpp"
+#include "grabthecam/cameracapturetemplates.hpp"
+#include "grabthecam/frameconverters/anyformat2bgrconverter.hpp"
+#include "grabthecam/frameconverters/packedformats2rgbconverter.hpp"
+#include "grabthecam/frameconverters/bayer2bgrconverter.hpp"
+#include "grabthecam/frameconverters/yuv2bgrconverter.hpp"
+#include "grabthecam/pixelformatsinfo.hpp"
+#include <opencv2/imgproc.hpp>
+
+#include "grabthecam/utils.hpp"
+
+int main(int argc, char** argv) {
+    if(argc < 2) {
+        std::cout << "Please give a video device path as an argument\n";
+        return 1;
+    }
+    grabthecam::CameraCapture camera(argv[1]);
+    for (const auto& entry : grabthecam::formats_info) {
+        camera.setFormat(1280, 720, entry.first);
+        cv::Mat frame = camera.capture();
+        char name[5] = {
+            (char)((uint32_t)(entry.first       ) & 0xff),
+            (char)((uint32_t)(entry.first >> 8  ) & 0xff),
+            (char)((uint32_t)(entry.first >> 16 ) & 0xff),
+            (char)((uint32_t)(entry.first >> 24 ) & 0xff),
+            0
+        };
+        std::string filename = "frame_" + std::string(name) + ".png";
+        grabthecam::saveToFile(filename, frame);
+    }
+    return 0;
+}


### PR DESCRIPTION
This PR implements support for various pixel format types listed in raviewer. Additionally, apart from YUY2, cameras typically support MJPEG and as listed this format was also added